### PR TITLE
install pigz to unarchive init.sql.gz

### DIFF
--- a/isucon3-qualifier/ansible/playbook.yml
+++ b/isucon3-qualifier/ansible/playbook.yml
@@ -134,6 +134,7 @@
         easy_install flask gunicorn python3-memcached PyMySQL3
 
     # bench
+    - yum: name=pigz
     - yum: name=libxml2-devel
     - sudo_user: isucon
       shell: |


### PR DESCRIPTION
ISUCON3 uses pigz to unarchive init.sql.gz before loading it to mysql.
But it is not installed in CentOS6 by default.
I suggest to install it.
