### PR TITLE
Fix provisioning message

### DIFF
--- a/isucon6-qualifier/Vagrantfile
+++ b/isucon6-qualifier/Vagrantfile
@@ -103,7 +103,7 @@ Vagrant.configure("2") do |config|
 
       usermod -G sudo -a -s /bin/bash isucon
 
-      echo "Provisioning Successful for image"
+      echo "Provisioning Successful for bench"
     SHELL
   end
   config.vm.define "image" do |web|


### PR DESCRIPTION
benchのprovisioningのmessageが `image` となっていたので修正しました。