### PR TITLE
add make command for isucon6-qualifier-standalone

### DIFF
--- a/isucon6-qualifier-standalone/Vagrantfile
+++ b/isucon6-qualifier-standalone/Vagrantfile
@@ -80,7 +80,7 @@ Vagrant.configure("2") do |config|
     set -e
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install -y --no-install-recommends ansible git aptitude golang-go tzdata
+    apt-get install -y --no-install-recommends ansible git aptitude golang-go tzdata make
     export GOPATH=/tmp/go
     mkdir -p ${GOPATH}/src/github.com/isucon/
     cd ${GOPATH}/src/github.com/isucon


### PR DESCRIPTION
error log

```
$ vagrant up
   :
==> default: Setting up golang-1.6-go (1.6.2-0ubuntu5~16.04.3) ...
==> default: Setting up golang-src (2:1.6-1ubuntu4) ...
==> default: Setting up golang-go (2:1.6-1ubuntu4) ...
==> default: Processing triggers for libc-bin (2.23-0ubuntu9) ...
==> default: Cloning into 'isucon6-qualify'...
==> default: /tmp/vagrant-shell: line 17: make: command not found
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

perhaps, isucon6-qualifier is fail, too. I don't check...

Thanks