### PR TITLE
Use scopes to perform specific configure

### DIFF
--- a/isucon5-qualifier/Vagrantfile
+++ b/isucon5-qualifier/Vagrantfile
@@ -76,7 +76,7 @@ Vagrant.configure(2) do |config|
   # SHELL
 
   config.vm.define "image" do |web|
-    config.vm.provision "shell", inline: <<-SHELL
+    web.vm.provision "shell", inline: <<-SHELL
       set -e
       sed -i.bak -e "s@http://us\.archive\.ubuntu\.com/ubuntu/@mirror://mirrors.ubuntu.com/mirrors.txt@g" /etc/apt/sources.list
       export DEBIAN_FRONTEND=noninteractive
@@ -94,7 +94,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.define "bench" do |bench|
-    config.vm.provision "shell", inline: <<-SHELL
+    bench.vm.provision "shell", inline: <<-SHELL
       set -e
       sed -i.bak -e "s@http://us\.archive\.ubuntu\.com/ubuntu/@mirror://mirrors.ubuntu.com/mirrors.txt@g" /etc/apt/sources.list
       export DEBIAN_FRONTEND=noninteractive

--- a/isucon6-qualifier/Vagrantfile
+++ b/isucon6-qualifier/Vagrantfile
@@ -76,8 +76,8 @@ Vagrant.configure("2") do |config|
   #   apt-get install -y apache2
   # SHELL
 
-  config.vm.define "bench" do |web|
-    config.vm.provision "shell", inline: <<-SHELL
+  config.vm.define "bench" do |bench|
+    bench.vm.provision "shell", inline: <<-SHELL
       set -e
       export DEBIAN_FRONTEND=noninteractive
       apt-get update
@@ -107,7 +107,7 @@ Vagrant.configure("2") do |config|
     SHELL
   end
   config.vm.define "image" do |web|
-    config.vm.provision "shell", inline: <<-SHELL
+    web.vm.provision "shell", inline: <<-SHELL
       set -e
       export DEBIAN_FRONTEND=noninteractive
       apt-get update


### PR DESCRIPTION
refs: https://www.vagrantup.com/docs/multi-machine/#defining-multiple-machines

config object affects any vms.
Before this, both image and bench ran provisioning both scripts.