### PR TITLE
Add EPEL repository before installing ansible

### DIFF
--- a/isucon8-qualifier-standalone/Vagrantfile
+++ b/isucon8-qualifier-standalone/Vagrantfile
@@ -77,6 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     set -e
     yum update -y
+    yum install -y epel-release
     yum install -y ansible git
 
     GITDIR="/tmp/torb"

--- a/isucon8-qualifier/Vagrantfile
+++ b/isucon8-qualifier/Vagrantfile
@@ -78,6 +78,7 @@ Vagrant.configure("2") do |config|
     webapp.vm.provision "shell", inline: <<-SHELL
       set -e
       yum update -y
+      yum install -y epel-release
       yum install -y ansible git
 
       GITDIR="/tmp/torb"
@@ -100,6 +101,7 @@ EOF
     bench.vm.provision "shell", inline: <<-SHELL
       set -e
       yum update -y
+      yum install -y epel-release
       yum install -y ansible git
 
       GITDIR="/tmp/torb"


### PR DESCRIPTION
Without installing `epel-release`, it fails to install `ansible` with the error message "No package ansible available.".

```
$ vagrant provision
==> webapp: Running provisioner: shell...
    webapp: Running: inline script
    webapp: Loaded plugins: fastestmirror
    webapp: Loading mirror speeds from cached hostfile
    webapp:  * base: ftp-srv2.kddilabs.jp
    webapp:  * extras: ftp-srv2.kddilabs.jp
    webapp:  * updates: ftp-srv2.kddilabs.jp
    webapp: No packages marked for update
    webapp: Loaded plugins: fastestmirror
    webapp: Loading mirror speeds from cached hostfile
    webapp:  * base: ftp-srv2.kddilabs.jp
    webapp:  * extras: ftp-srv2.kddilabs.jp
    webapp:  * updates: ftp-srv2.kddilabs.jp
    webapp: No package ansible available.
    webapp: Package git-1.8.3.1-23.el7_8.x86_64 already installed and latest version
    webapp: Nothing to do
    webapp: Cloning into '/tmp/torb'...
    webapp: /tmp/vagrant-shell: line 15: ansible-playbook: command not found
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

After adding those lines, `vagrant provision` works fine on my end.