### PR TITLE
fix deploying images of bench

### DIFF
--- a/isucon11-qualifier-standalone/Vagrantfile
+++ b/isucon11-qualifier-standalone/Vagrantfile
@@ -90,6 +90,7 @@ Vagrant.configure("2") do |config|
 
       # bench
       curl -sL https://github.com/isucon/isucon11-qualify/releases/download/public/initialize.json > roles/bench/files/initialize.json
+      curl -sL https://github.com/isucon/isucon11-qualify/releases/download/public/images.tgz > roles/bench/files/images.tgz
       sed -i -e '/InsecureSkipVerify/s/=.*/= true/' ../../bench/main.go
       sed -i -e 's/tls\.Config{}/tls.Config{InsecureSkipVerify: true}/' -e '/ServerName:/a			InsecureSkipVerify: true,' ../../bench/scenario/posting.go
 


### PR DESCRIPTION
vagrant up すると、bench用のansibleの実行途中で以下のエラーで止まるようなので、修正しました。
```
    default: TASK [bench : roles/bench/tasks/bench: Deploy images] **************************
    default: Tuesday 21 September 2021  02:43:57 +0000 (0:00:00.216)       0:36:18.689 *****
    default: fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Could not find or access 'images.tgz'\nSearched in:\n\t/tmp/isucon11-qualify/provisioning/ansible/roles/bench/files/images.tgz\n\t/tmp/isucon11-qualify/provisioning/ansible/roles/bench/images.tgz\n\t/tmp/isucon11-qualify/provisioning/ansible/roles/bench/tasks/files/images.tgz\n\t/tmp/isucon11-qualify/provisioning/ansible/roles/bench/tasks/images.tgz\n\t/tmp/isucon11-qualify/provisioning/ansible/files/images.tgz\n\t/tmp/isucon11-qualify/provisioning/ansible/images.tgz on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
    default: 
```